### PR TITLE
Add graceful handling of keyboard interrupts

### DIFF
--- a/video_to_ascii/cli.py
+++ b/video_to_ascii/cli.py
@@ -17,8 +17,10 @@ def main():
 
     ARGS = PARSER.parse_args()
 
-    player.play(ARGS.file, strategy=ARGS.strategy, output=ARGS.output, play_audio=ARGS.with_audio)
-
+    try:
+        player.play(ARGS.file, strategy=ARGS.strategy, output=ARGS.output, play_audio=ARGS.with_audio)
+    except (KeyboardInterrupt):
+        pass
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Allow ASCII movies playing on the terminal to be stopped using keyboard interrupts (ctrl+c) without printing nasty stack traces.