### PR TITLE
Fix typo in README and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Standard installation
 ```bash
 pip3 install video-to-ascii
 ```
-With audio support installtion
+With audio support installation
 ```bash
 pip3 install video-to-ascii --install-option="--with-audio"
 ```
@@ -45,12 +45,12 @@ $ video-to-ascii -f myvideo.mp4
 ### Options
 
 **--strategy**
-Allow to choose an strategy to render the output
+Allow to choose an strategy to render the output.
 
 ![strategies](images/Strategies.png)
 
 **-o --output**
-Export the rendering output to a bash file to share with someone
+Export the rendering output to a bash file to share with someone.
 
 ![strategies](images/export.png)
 
@@ -109,9 +109,9 @@ This project exists thanks to all the people who contribute. [[Contribute](CONTR
 
 ### Financial Contributors
 
-Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/funny-opensource-projects/contribute)]
+Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/funny-opensource-projects/contribute)].
 
-Or maybe just [buy me a coffee](ko-fi.com/joelibaceta)
+Or maybe just [buy me a coffee](ko-fi.com/joelibaceta).
 
 #### Individuals
 

--- a/video_to_ascii/render_strategy/ascii_bw_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_bw_strategy.py
@@ -1,5 +1,5 @@
 """
-This module contains a class AsciiColorStrategy, o process video frames and build an ascii output
+This module contains a class AsciiColorStrategy, to process video frames and build an ascii output
 """
 
 from . import ascii_strategy as strategy

--- a/video_to_ascii/render_strategy/ascii_color_filled_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_color_filled_strategy.py
@@ -1,5 +1,5 @@
 """
-This module contains a class AsciiColorStrategy, o process video frames and build an ascii output
+This module contains a class AsciiColorStrategy, to process video frames and build an ascii output
 """
 
 from . import ascii_strategy as strategy

--- a/video_to_ascii/render_strategy/ascii_color_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_color_strategy.py
@@ -1,5 +1,5 @@
 """
-This module contains a class AsciiColorStrategy, o process video frames and build an ascii output
+This module contains a class AsciiColorStrategy, to process video frames and build an ascii output
 """
 
 from . import ascii_strategy as strategy

--- a/video_to_ascii/render_strategy/ascii_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_strategy.py
@@ -1,5 +1,5 @@
 """
-This module contains a class AsciiColorStrategy, o process video frames and build an ascii output
+This module contains a class AsciiColorStrategy, to process video frames and build an ascii output
 """
 
 import time
@@ -67,7 +67,7 @@ class AsciiStrategy(re.RenderStrategy):
         """
         Iterate each video frame to print a set of ascii chars
 
-        This method read each video frame from a opencv video capture
+        This method reads each video frame from a opencv video capture
         resizing the frame and truncate the width if necessary to
         print correcly the final string builded with the method
         convert_frame_pixels_to_ascii.
@@ -163,7 +163,7 @@ class AsciiStrategy(re.RenderStrategy):
         Resize a frame to meet the terminal dimensions
 
         Calculating the output terminal dimensions (cols, rows),
-        we can to get a reduction factor to resize the frame
+        we can get a reduction factor to resize the frame
         according to the height of the terminal mainly
         to print each frame at a time, using all the available rows
 


### PR DESCRIPTION
-Fix minor typo in README.
-Fix minor typo in comments: ascii_bw_strategy.py , ascii_color_filled_strategy.py , ascii_color_strategy.py and ascii_strategy.py .
