### PR TITLE
replace time.clock() with time.process_time()

### DIFF
--- a/video_to_ascii/render_strategy/ascii_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_strategy.py
@@ -115,9 +115,7 @@ class AsciiStrategy(re.RenderStrategy):
         sys.stdout.write("echo -en '\033[2J' \n")
         # read each frame
         while cap.isOpened():
-
-
-            t0 = time.clock()
+            t0 = time.process_time()
             rows, cols = os.popen('stty size', 'r').read().split()
             _ret, frame = cap.read()
             if frame is None:


### PR DESCRIPTION
Because clock api is removed on Python3.8.