### PR TITLE
fixed output issue for windows

### DIFF
--- a/video_to_ascii/render_strategy/ascii_bw_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_bw_strategy.py
@@ -3,7 +3,11 @@ This module contains a class AsciiColorStrategy, to process video frames and bui
 """
 
 from . import ascii_strategy as strategy
-from . import image_processor as ipe
+import sys
+if sys.platform != 'win32':
+    from . import image_processor as ipe
+else:
+    from . import image_processor_win as ipe
 
 class AsciiBWStrategy(strategy.AsciiStrategy):
     """Print each frame in the terminal using one color ascii characters"""

--- a/video_to_ascii/render_strategy/ascii_color_filled_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_color_filled_strategy.py
@@ -3,7 +3,12 @@ This module contains a class AsciiColorStrategy, to process video frames and bui
 """
 
 from . import ascii_strategy as strategy
-from . import image_processor as ipe
+import sys
+
+if sys.platform != 'win32':
+    from . import image_processor as ipe
+else:
+    from . import image_processor_win as ipe
 
 class AsciiColorFilledStrategy(strategy.AsciiStrategy):
     """Print each frame in the terminal using ascii characters"""

--- a/video_to_ascii/render_strategy/ascii_color_strategy.py
+++ b/video_to_ascii/render_strategy/ascii_color_strategy.py
@@ -3,7 +3,11 @@ This module contains a class AsciiColorStrategy, to process video frames and bui
 """
 
 from . import ascii_strategy as strategy
-from . import image_processor as ipe
+import sys
+if sys.platform != 'win32':
+    from . import image_processor as ipe
+else:
+    from . import image_processor_win as ipe
 
 class AsciiColorStrategy(strategy.AsciiStrategy):
     """Print each frame in the terminal using ascii characters"""

--- a/video_to_ascii/render_strategy/image_processor_win.py
+++ b/video_to_ascii/render_strategy/image_processor_win.py
@@ -1,13 +1,26 @@
 """Module with useful functions to image processing"""
+"""Windows-compatibility module"""
 
+from colored import fg, attr
 import colorsys
-from xtermcolor import colorize
 
 CHARS_LIGHT = [' ', ' ', '.', ':', '!', '+', '*', 'e', '$', '@', '8']
 CHARS_COLOR = ['.', '*', 'e', 's', '◍']
 CHARS_FILLED = ['░', '▒', '▓', '█']
 
 DENSITY = [CHARS_LIGHT, CHARS_COLOR, CHARS_FILLED]
+
+def rgb_to_colorhex(r, g, b):
+    R = format(int(r), 'x')
+    if len(R) == 1:
+        R = '0'+format(int(r), 'x')
+    G = format(int(g), 'x')
+    if len(G) == 1:
+        G = '0'+format(int(g), 'x')
+    B = format(int(b), 'x')
+    if len(B) == 1:
+        B = '0'+format(int(b), 'x')
+    return f'#{R.upper()}{G.upper()}{B.upper()}'
 
 def brightness_to_ascii(i, density=0):
     """
@@ -18,11 +31,11 @@ def brightness_to_ascii(i, density=0):
     index = int(size * i / 255)
     return chars_collection[index]
 
-def colorize_char(char, ansi_color):
+def colorize_char(char, colorhex):
     """
     Get an appropriate char of brightness from a rgb color
     """
-    str_colorized = colorize(char, ansi=ansi_color)
+    str_colorized = fg(colorhex)+char+attr('reset')
     return str_colorized
 
 def pixel_to_ascii(pixel, colored=True, density=0):
@@ -36,8 +49,9 @@ def pixel_to_ascii(pixel, colored=True, density=0):
         bright = rgb_to_brightness(*rgb)
         rgb = increase_saturation(*rgb)
         char = brightness_to_ascii(bright, density)
-        ansi_color = rgb_to_ansi(*rgb)
-        char = colorize(char*2, ansi=ansi_color)
+        hex_color = rgb_to_colorhex(*rgb)
+##        print("===\n"+hex_color+"\n===\n")
+        char = fg(hex_color)+char*2+attr('reset')
     else:
         bright = rgb_to_brightness(*rgb, grayscale=True)
         char = brightness_to_ascii(bright, density)
@@ -61,21 +75,21 @@ def rgb_to_brightness(r, g, b, grayscale=False):
     else:
         return 0.267*r + 0.642*g + 0.091*b
 
-def rgb_to_ansi(r, g, b):
-    """
-    Convert an rgb color to ansi color
-    """
-    (r, g, b) = int(r), int(g), int(b)
-    if r == g & g == b:
-        if r < 8:
-            return int(16)
-        if r > 248:
-            return int(230)
-        return int(round(((r - 8) / 247) * 24) + 232)
-
-    to_ansi_range = lambda a: int(round(a / 51.0))
-    r_in_range = to_ansi_range(r)
-    g_in_range = to_ansi_range(g)
-    b_in_range = to_ansi_range(b)
-    ansi = 16 + (36 * r_in_range) + (6 * g_in_range) + b_in_range
-    return int(ansi)
+##def rgb_to_ansi(r, g, b):
+##    """
+##    Convert an rgb color to ansi color
+##    """
+##    (r, g, b) = int(r), int(g), int(b)
+##    if r == g & g == b:
+##        if r < 8:
+##            return int(16)
+##        if r > 248:
+##            return int(230)
+##        return int(round(((r - 8) / 247) * 24) + 232)
+##
+##    to_ansi_range = lambda a: int(round(a / 51.0))
+##    r_in_range = to_ansi_range(r)
+##    g_in_range = to_ansi_range(g)
+##    b_in_range = to_ansi_range(b)
+##    ansi = 16 + (36 * r_in_range) + (6 * g_in_range) + b_in_range
+##    return int(ansi)

--- a/video_to_ascii/render_strategy/image_processor_win.py
+++ b/video_to_ascii/render_strategy/image_processor_win.py
@@ -50,7 +50,6 @@ def pixel_to_ascii(pixel, colored=True, density=0):
         rgb = increase_saturation(*rgb)
         char = brightness_to_ascii(bright, density)
         hex_color = rgb_to_colorhex(*rgb)
-##        print("===\n"+hex_color+"\n===\n")
         char = fg(hex_color)+char*2+attr('reset')
     else:
         bright = rgb_to_brightness(*rgb, grayscale=True)
@@ -74,22 +73,3 @@ def rgb_to_brightness(r, g, b, grayscale=False):
         return 0.2126*r + 0.7152*g + 0.0722*b
     else:
         return 0.267*r + 0.642*g + 0.091*b
-
-##def rgb_to_ansi(r, g, b):
-##    """
-##    Convert an rgb color to ansi color
-##    """
-##    (r, g, b) = int(r), int(g), int(b)
-##    if r == g & g == b:
-##        if r < 8:
-##            return int(16)
-##        if r > 248:
-##            return int(230)
-##        return int(round(((r - 8) / 247) * 24) + 232)
-##
-##    to_ansi_range = lambda a: int(round(a / 51.0))
-##    r_in_range = to_ansi_range(r)
-##    g_in_range = to_ansi_range(g)
-##    b_in_range = to_ansi_range(b)
-##    ansi = 16 + (36 * r_in_range) + (6 * g_in_range) + b_in_range
-##    return int(ansi)


### PR DESCRIPTION
fixed output issues for windows 10 users who use CMD where the output would be uncolored, as well as adding in `os.get_terminal_size()` as an alt for `stty size` for windows.

output sometimes isn't centered is still an issue to be fixed.
the PR also uses `colored`, an alt for `xtermcolor` for windows 10 cmd. I haven't tested it on a different computer; currently the video goes 1 frame per 3s on my laptop, probably because it can't process a lot on my current low-end device.

also this is my first time to perform a PR. im open to hear what you think about this change. ^^
p.s.: i just dragged the files into my fork `master` branch, which Github didn't detect the actual line changes, thus including the full contents of the new/changed files as "new lines of code" with nothing much changed in it. weird