### PR TITLE
fixing setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def install_package(package):
     import pip
     try:
         from pip._internal import main
-        main.main(['install', package])
+        main(['install', package])
     except AttributeError:
         from pip import __main__
         __main__._main(['install', package])


### PR DESCRIPTION
please accept this. because this happens when i write ` pip install video-to-ascii `

Collecting video-to-ascii
  Using cached video_to_ascii-1.3.0.tar.gz (6.9 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "C:\Users\amaur\AppData\Local\Temp\pip-install-xf281c3r\video-to-ascii_6e9fa45a31604302833e8aeb62c479f8\setup.py", line 11, in install_package
          main.main(['install', package])
          ^^^^^^^^^
      AttributeError: 'function' object has no attribute 'main'

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\amaur\AppData\Local\Temp\pip-install-xf281c3r\video-to-ascii_6e9fa45a31604302833e8aeb62c479f8\setup.py", line 21, in <module>
          install_package('opencv-python')
        File "C:\Users\amaur\AppData\Local\Temp\pip-install-xf281c3r\video-to-ascii_6e9fa45a31604302833e8aeb62c479f8\setup.py", line 14, in install_package
          __main__._main(['install', package])
          ^^^^^^^^^^^^^^
      AttributeError: module 'pip.__main__' has no attribute '_main'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

changing main.main(['install', package]) to  main(['install', package]) will work?